### PR TITLE
wadors (loadimage) must return a deferred like wadouri does

### DIFF
--- a/src/imageLoaders/wadors/wadors.js
+++ b/src/imageLoaders/wadors/wadors.js
@@ -45,7 +45,7 @@
       deferred.reject(reason);
     });
 
-    return deferred.promise();
+    return deferred;
   }
 
   // registery dicomweb and wadouri image loader prefixes


### PR DESCRIPTION
If a promise is returned instead of a deferred, imageCache
(purgeCacheIfNecessary) will break because it calls reject()
on every item removed from cache.