### PR TITLE
Support for loading frames using WADO-RS (octet-stream)

### DIFF
--- a/src/imageLoader/createImage.js
+++ b/src/imageLoader/createImage.js
@@ -14,11 +14,6 @@
       sopClassUid !== '1.2.840.10008.5.1.4.1.1.12.2.1	'; // XRF
   }
 
-  function getSizeInBytes(imageFrame) {
-    var bytesPerPixel = Math.round(imageFrame.bitsAllocated / 8);
-    return imageFrame.rows * imageFrame.columns * bytesPerPixel * imageFrame.samplesPerPixel;
-  }
-
   /**
    * Helper function to set pixel data to the right typed array.  This is needed because web workers
    * can transfer array buffers but not typed arrays
@@ -62,7 +57,7 @@
         render: undefined, // set below
         rowPixelSpacing: imagePlaneModule.pixelSpacing ? imagePlaneModule.pixelSpacing[0] : undefined,
         rows: imageFrame.rows,
-        sizeInBytes: getSizeInBytes(imageFrame),
+        sizeInBytes: imageFrame.pixelData.length,
         slope: modalityLutModule.rescaleSlope ? modalityLutModule.rescaleSlope: 1,
         width: imageFrame.columns,
         windowCenter: voiLutModule.windowCenter ? voiLutModule.windowCenter[0] : undefined,

--- a/src/imageLoader/wadors/getPixelData.js
+++ b/src/imageLoader/wadors/getPixelData.js
@@ -67,7 +67,9 @@
       var length = endIndex - offset;
       deferred.resolve({
         contentType: findContentType(split),
-        imageFrame: new Uint8Array(imageFrameAsArrayBuffer, offset, length)
+        imageFrame: {
+          pixelData: new Uint8Array(imageFrameAsArrayBuffer, offset, length)
+        }
       });
     });
     return deferred.promise();    

--- a/src/imageLoader/wadors/getPixelData.js
+++ b/src/imageLoader/wadors/getPixelData.js
@@ -45,7 +45,7 @@
       var response = new Uint8Array(imageFrameAsArrayBuffer);
 
       // First look for the multipart mime header
-      var tokenIndex = cornerstoneWADOImageLoader.wadors.findIndexOfString(response, '\n\r\n');
+      var tokenIndex = cornerstoneWADOImageLoader.wadors.findIndexOfString(response, '\r\n\r\n');
       if(tokenIndex === -1) {
         deferred.reject('invalid response - no multipart mime header');
       }
@@ -56,15 +56,18 @@
       if(!boundary) {
         deferred.reject('invalid response - no boundary marker')
       }
-      var offset = tokenIndex + 3; // skip over the \n\r\n
+      var offset = tokenIndex + 4; // skip over the \r\n\r\n
 
       // find the terminal boundary marker
       var endIndex = cornerstoneWADOImageLoader.wadors.findIndexOfString(response, boundary, offset);
       if(endIndex === -1) {
         deferred.reject('invalid response - terminating boundary not found');
       }
+
+      // Remove \r\n from the length
+      var length = endIndex - offset - 2;
+
       // return the info for this pixel data
-      var length = endIndex - offset;
       deferred.resolve({
         contentType: findContentType(split),
         imageFrame: {

--- a/src/imageLoader/wadors/loadImage.js
+++ b/src/imageLoader/wadors/loadImage.js
@@ -23,7 +23,7 @@
 
     // TODO: load bulk data items that we might need
 
-    var mediaType;// = 'image/dicom+jp2';
+    var mediaType = 'multipart/related; type=application/octet-stream'; // 'image/dicom+jp2';
 
     // get the pixel data from the server
     cornerstoneWADOImageLoader.wadors.getPixelData(uri, imageId, mediaType).then(function(result) {

--- a/src/imageLoader/wadors/metaData/metaDataProvider.js
+++ b/src/imageLoader/wadors/metaData/metaDataProvider.js
@@ -37,8 +37,13 @@
         planarConfiguration: getValue(metaData['00280006']),
         pixelAspectRatio: getValue(metaData['00280034']),
         smallestPixelValue: getValue(metaData['00280106']),
-        largestPixelValue: getValue(metaData['00280107'])
-        // TODO Color Palette
+        largestPixelValue: getValue(metaData['00280107']),
+        redPaletteColorLookupTableDescriptor: getNumberValues(metaData['00281101']),
+        greenPaletteColorLookupTableDescriptor: getNumberValues(metaData['00281102']),
+        bluePaletteColorLookupTableDescriptor: getNumberValues(metaData['00281103']),
+        redPaletteColorLookupTableData: getNumberValues(metaData['00281201']),
+        greenPaletteColorLookupTableData: getNumberValues(metaData['00281202']),
+        bluePaletteColorLookupTableData: getNumberValues(metaData['00281203'])
       };
     }
 

--- a/src/imageLoader/wadouri/dataSetCacheManager.js
+++ b/src/imageLoader/wadouri/dataSetCacheManager.js
@@ -51,7 +51,6 @@
 
     // This uri is not loaded or being loaded, load it via an xhrRequest
     var promise = loadRequest(uri, imageId);
-    promises[uri] = promise;
 
     // handle success and failure of the XHR request load
     var loadDeferred = $.Deferred();
@@ -71,6 +70,8 @@
         // error thrown, remove the promise
         delete promises[uri];
       });
+
+    promises[uri] = loadDeferred;
     return loadDeferred;
   }
 


### PR DESCRIPTION
**Example of a WADO-RS (frame) request:**

curl http://localhost:8042/dicom-web/studies/2.16.840.1.113669.632.20.1211.10000315526/series/1.3.12.2.1107.5.1.4.54693.30000006100507010800000005268/instances/1.3.12.2.1107.5.1.4.54693.30000006100507010800000005466/frames/1 -H 'accept: multipart/related; type=application/octet-stream'

**Documentation**
http://book.orthanc-server.com/plugins/dicomweb.html