### PR TITLE
image.sizeInBytes should be the image size instead of dataset size

### DIFF
--- a/src/makeColorImage.js
+++ b/src/makeColorImage.js
@@ -27,8 +27,7 @@
         var rescaleSlopeAndIntercept = cornerstoneWADOImageLoader.getRescaleSlopeAndIntercept(dataSet);
         var bytesPerPixel = 4;
         var numPixels = rows * columns;
-        //var sizeInBytes = numPixels * bytesPerPixel;
-        var sizeInBytes = dataSet.byteArray.length;
+        var sizeInBytes = numPixels * bytesPerPixel;
         var windowWidthAndCenter = cornerstoneWADOImageLoader.getWindowWidthAndCenter(dataSet);
 
         // clear the lastImageIdDrawn so we update the canvas

--- a/src/makeGrayscaleImage.js
+++ b/src/makeGrayscaleImage.js
@@ -71,8 +71,7 @@
         }
 
         var numPixels = rows * columns;
-        //var sizeInBytes = numPixels * bytesPerPixel;
-        var sizeInBytes = dataSet.byteArray.length;
+        var sizeInBytes = numPixels * bytesPerPixel;
         var photometricInterpretation = dataSet.string('x00280004');
         var invert = (photometricInterpretation === "MONOCHROME1");
         var windowWidthAndCenter = cornerstoneWADOImageLoader.getWindowWidthAndCenter(dataSet);


### PR DESCRIPTION
Working with dataset size instead of image size breaks the imageCache that
counts the wrong size resulting in a memory consumption above the normal
mainly when loading compressed datasets.

We got a lot of issues on OHIF because the client is loading some compressed dataset (50:1, 20:1 and 10:1) and imageCache is consuming +3GB of memory. For a 100MB dataset it's counting only 2MB when working with 50:1 compression rate.

Pull request [#85](https://github.com/chafey/cornerstone/pull/85) on cornerstone must be approved  at the same time to get this working properly because that commit changes the way imageCache counts the images size.