### PR TITLE
wadouri: loadDataSetFromPromise should return a deferred instead of a promise

### DIFF
--- a/src/imageLoader/wadouri/loadImage.js
+++ b/src/imageLoader/wadouri/loadImage.js
@@ -43,7 +43,7 @@
     }, function(error) {
       deferred.reject(error);
     });
-    return deferred.promise();
+    return deferred;
   }
 
   function getLoaderForScheme(scheme) {


### PR DESCRIPTION
`imageCache` stop working when a `promise` is returned instead of a `deferred`