### PR TITLE
Corrected typo "licnense"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     ],
     "author": "Chris Hafey",
     "homepage": "https://github.com/chafey/cornerstoneWADOImageLoader",
-    "licnense": "MIT",
+    "license": "MIT",
     "repository": {
         "type": "git",
         "url": "https://github.com/chafey/cornerstoneWADOImageLoader.git"


### PR DESCRIPTION
Corrected typo "licnense" in package.json