### PR TITLE
OHIF #89 Do not use color palette luts if photometric interpretation is not ‘PALETTE COLOR’

### DIFF
--- a/src/imageLoader/wadouri/metaData/getImagePixelModule.js
+++ b/src/imageLoader/wadouri/metaData/getImagePixelModule.js
@@ -26,8 +26,8 @@ function getLutData (lutDataSet, tag, lutDescriptor) {
 }
 
 function populatePaletteColorLut (dataSet, imagePixelModule) {
-  // return immediately if no palette lut elements
-  if (!dataSet.elements.x00281101) {
+  // return immediately if photometric interpretation is not PALETTE COLOR and no palette lut elements
+  if (imagePixelModule.photometricInterpretation !== 'PALETTE COLOR' || !dataSet.elements.x00281101) {
     return;
   }
   imagePixelModule.redPaletteColorLookupTableDescriptor = getLutDescriptor(dataSet, 'x00281101');

--- a/src/imageLoader/wadouri/metaData/getImagePixelModule.js
+++ b/src/imageLoader/wadouri/metaData/getImagePixelModule.js
@@ -26,7 +26,7 @@ function getLutData (lutDataSet, tag, lutDescriptor) {
 }
 
 function populatePaletteColorLut (dataSet, imagePixelModule) {
-  // return immediately if photometric interpretation is not PALETTE COLOR and no palette lut elements
+  // return immediately if photometric interpretation is not PALETTE COLOR or no palette lut elements
   if (imagePixelModule.photometricInterpretation !== 'PALETTE COLOR' || !dataSet.elements.x00281101) {
     return;
   }


### PR DESCRIPTION
This is originally an issue from OHIF: https://github.com/OHIF/Viewers/issues/89

According to DICOM standard, color palette luts should be used only if photometric interpretation is 'PALETTE COLOR'. This fix checks it.

Here is the reference: http://dicom.nema.org/medical/dicom/2014c/output/chtml/part03/sect_C.7.6.3.html