### PR TITLE
Bug/support metadata fields for cornerstone tools reference lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "webpack": "^3.1.0"
   },
   "dependencies": {
+    "cornerstone-math": "^0.1.6",
     "dicom-parser": "^1.7.4",
     "jquery": "^3.2.1"
   }

--- a/src/externalModules.js
+++ b/src/externalModules.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import * as dicomParser from 'dicom-parser';
+import * as cornerstoneMath from 'cornerstone-math';
 import registerLoaders from './imageLoader/registerLoaders.js';
 
 let cornerstone;
@@ -15,4 +16,4 @@ const external = {
   }
 };
 
-export { $, dicomParser, external };
+export { $, dicomParser, cornerstoneMath, external };


### PR DESCRIPTION
- Adds `cornerstone-math` dependency
- Updates `imagePlaneModule` to provide metaData fields necessary for reference line tool to work out of the box

Inspiration taken from the OHIF viewer. I have not thoroughly tested this. To avoid adding a dependency, it makes me wonder if it's worth pulling out the metaDataProvider (especially as I feel it's one of the first pieces someone would provide their own implementation of).

Bug: https://github.com/chafey/cornerstoneTools/issues/242